### PR TITLE
preserve line breaks

### DIFF
--- a/src/writeSnapshots.js
+++ b/src/writeSnapshots.js
@@ -9,6 +9,7 @@ const writeSnapshots = (snaps, snapshotFilePath) => {
       const snapshot = JSON.stringify(value, null, "\t")
         .replace(/\\n/g, '\n')
         .replace(/`/g, '\\`')
+        .replace(/\${/g, '\\${')
         .replace(/(^")|("$)/g, '`');
 
       return `${prev}exports["${name}"] = ${snapshot};\n\n`;

--- a/src/writeSnapshots.js
+++ b/src/writeSnapshots.js
@@ -4,8 +4,15 @@ const checkCI = require("./checkCI");
 const writeSnapshots = (snaps, snapshotFilePath) => {
   checkCI();
 
-  const snapsFileContent = Object.keys(snaps).reduce(
-    (prev, curr) => `${prev}exports["${curr}"] = ${JSON.stringify(snaps[curr], null, "\t")};\n\n`,
+  const snapsFileContent = Object.entries(snaps).reduce(
+    (prev, [name, value]) => {
+      const snapshot = JSON.stringify(value, null, "\t")
+        .replace(/\\n/g, '\n')
+        .replace(/`/g, '\\`')
+        .replace(/(^")|("$)/g, '`');
+
+      return `${prev}exports["${name}"] = ${snapshot};\n\n`;
+    },
     ""
   );
 


### PR DESCRIPTION
fixes #2 

This PR replaces line breaks with actual `\n` in the snapshot file output. To do that it wraps the value itself in backticks and escapes any backticks in the actual snapshot.

For the lack of tests I'm not sure what could be missing here...